### PR TITLE
[CIDL-4] Added Secure Channel Insights dashboard

### DIFF
--- a/dashboards/Secure_Channel_Insights.dashboard.lookml
+++ b/dashboards/Secure_Channel_Insights.dashboard.lookml
@@ -56,14 +56,14 @@
     col: 0
     width: 17
     height: 2
-  - title: Less Secure Ciphers seen in the period
-    name: Less Secure Ciphers seen in the period
+  - title: Less Secure Ciphers Seen in the Period
+    name: Less Secure Ciphers Seen in the Period
     model: corelight-chronicle
     explore: events
     type: looker_grid
     fields: [events.network__tls__cipher, events.last_target_ip, events__about__labels__uid__only.distinct_uid_only_count,
       events.values_host_type_less_secure_cipher, events.values_direction_less_secure_cipher,
-      events.less_secure_cipher_seen_in_the_period_link]
+      events.metadata_id_count, events.less_secure_cipher_seen_in_the_period_link]
     filters:
       events.metadata__product_event_type: ssl
       events.match_cipher: 'Yes'
@@ -114,6 +114,7 @@
       events.values_host_type_less_secure_cipher: Host Type
       events.values_direction_less_secure_cipher: Direction
       events.less_secure_cipher_seen_in_the_period_link: Raw Logs
+      events.metadata_id_count: Count
     series_cell_visualizations: {}
     hidden_pivots: {}
     defaults_version: 1
@@ -180,13 +181,13 @@
       Global Time Restriction: events.event_timestamp_time
       Sensor: events.observer__hostname
       Namespace: events.observer__namespace
-      Traffic Direction(For TLS Versions): events.connection_type
+      Traffic Direction(Only for TLS Versions): events.connection_type
     row: 11
     col: 0
     width: 5
     height: 3
-  - title: Network Evidence for All TLS versions seen
-    name: Network Evidence for All TLS versions seen
+  - title: Network Evidence for All TLS Versions Seen
+    name: Network Evidence for All TLS Versions Seen
     model: corelight-chronicle
     explore: events
     type: looker_grid
@@ -237,7 +238,7 @@
       Global Time Restriction: events.event_timestamp_time
       Sensor: events.observer__hostname
       Namespace: events.observer__namespace
-      Traffic Direction(For TLS Versions): events.connection_type
+      Traffic Direction(Only for TLS Versions): events.connection_type
     row: 14
     col: 0
     width: 12
@@ -280,7 +281,7 @@
     explore: events
     type: looker_grid
     fields: [events__about__labels__uid__only.value, events__principal__ip.events__principal__ip,
-      events__target__ip.events__target__ip, events.inference, events__security_result.description,
+      events__target__ip.events__target__ip, events.values_inference, events.values_description,
       events.metadata_id_count, events.interactive_sessions_and_keystrokes_link]
     filters:
       events.metadata__product_event_type: ssh
@@ -306,7 +307,8 @@
     show_sql_query_menu_options: false
     column_order: ["$$$_row_numbers_$$$", events__about__labels__uid__only.value,
       events__principal__ip.events__principal__ip, events__target__ip.events__target__ip,
-      events.inference, events__security_result.description, events.metadata_id_count]
+      events.values_inference, events.values_description, events.metadata_id_count,
+      events.interactive_sessions_and_keystrokes_link]
     show_totals: true
     show_row_totals: true
     truncate_header: false
@@ -315,11 +317,11 @@
       events__about__labels__uid__only.value: UID
       events__target__ip.events__target__ip: Dest IP
       events__principal__ip.events__principal__ip: Src IP
-      events__security_result.summary: Inference
       events.metadata_id_count: Count
-      events__security_result.description: Description
       events.network_evidence_for_interactive_sessions_and_keystrokes_link: Raw Logs
       events.interactive_sessions_and_keystrokes_link: Raw Logs
+      events.values_inference: Inferences
+      events.values_description: Description
     series_cell_visualizations:
       events__about__labels__uid__only.distinct_uid_only_count:
         is_active: false
@@ -511,7 +513,7 @@
     explore: events
     type: looker_grid
     fields: [events__about__labels__uid__only.value, events__principal__ip.events__principal__ip,
-      events__target__ip.events__target__ip, events.inference, events__security_result.description,
+      events__target__ip.events__target__ip, events.values_inference, events.values_description,
       events.metadata_id_count, events.possible_file_transfer_link]
     filters:
       events.metadata__product_event_type: ssh
@@ -541,13 +543,13 @@
     minimum_column_width:
     series_labels:
       events__target__ip.events__target__ip: Dest IP
-      events__security_result.summary: inference
-      events__security_result.description: Description
       events.metadata_id_count: Count
       events.inference: Inference
       events.possible_file_transfer_link: Raw Logs
       events__about__labels__uid__only.value: UID
       events__principal__ip.events__principal__ip: Src IP
+      events.values_inference: Inferences
+      events.values_description: Description
     series_cell_visualizations:
       events.metadata_id_count:
         is_active: false
@@ -823,14 +825,14 @@
     col: 12
     width: 5
     height: 3
-  - title: SSH Advanced Threats Infereces
-    name: SSH Advanced Threats Infereces
+  - title: SSH Advanced Threats Inferences
+    name: SSH Advanced Threats Inferences
     model: corelight-chronicle
     explore: events
     type: looker_grid
     fields: [events__about__labels__uid__only.value, events__principal__ip.events__principal__ip,
-      events__target__ip.events__target__ip, events.inference, events.metadata_id_count,
-      events__security_result.description, events.ssh_advance_threat_inferences_link]
+      events__target__ip.events__target__ip, events.values_inference, events.metadata_id_count,
+      events.values_description, events.ssh_advance_threat_inferences_link]
     filters:
       events.metadata__product_event_type: ssh
       events.inference: ABP,RSP,RSI,RSIA,RSL,RSK
@@ -855,7 +857,8 @@
     show_sql_query_menu_options: false
     column_order: ["$$$_row_numbers_$$$", events__about__labels__uid__only.value,
       events__principal__ip.events__principal__ip, events__target__ip.events__target__ip,
-      events.inference, events.metadata_id_count, events__security_result.description]
+      events.values_inference, events.metadata_id_count, events.values_description,
+      events.ssh_advance_threat_inferences_link]
     show_totals: true
     show_row_totals: true
     truncate_header: false
@@ -864,10 +867,10 @@
       events__about__labels__uid__only.value: UID
       events__principal__ip.events__principal__ip: Src IP
       events__target__ip.events__target__ip: Dest IP
-      events.inference: Inference
-      events__security_result.description: Description
       events.metadata_id_count: Count
       events.ssh_advance_threat_inferences_link: Raw Logs
+      events.values_inference: Inferences
+      events.values_description: Description
     series_cell_visualizations:
       events.metadata_id_count:
         is_active: false
@@ -1002,7 +1005,7 @@
     model: corelight-chronicle
     explore: events
     type: looker_grid
-    fields: [events.network__tls__client__server_name, events__target__ip.events__target__ip,
+    fields: [events.network__tls__client__server_name_not_null, events__target__ip.events__target__ip,
       events.target__port, x509_events_only.certificate_key_length, is_ip_internal_external.dest_host_type,
       events.metadata_id_count, events.weak_key_length_certs_link]
     filters:
@@ -1034,14 +1037,14 @@
     truncate_header: false
     minimum_column_width:
     series_labels:
-      events.network__tls__client__server_name: Server Name
       events__target__ip.events__target__ip: Dest Host
-      events.target__port: Dest Port
+      events.target__port: Resp Port
       x509_events_only.certificate_key_length: Key Length
       is_ip_internal_external.dest_host_type: Host Type
       events.metadata_id_count: Count
       events.network_evidence_for_weak_key_length_certs_link: Raw Logs
       events.weak_key_length_certs_link: Raw Logs
+      events.network__tls__client__server_name_not_null: Server Name
     series_cell_visualizations:
       events.metadata_id_count:
         is_active: false
@@ -1185,8 +1188,8 @@
     col: 0
     width: 12
     height: 6
-  - title: Certificates about to Expire
-    name: Certificates about to Expire
+  - title: Certificates About to Expire
+    name: Certificates About to Expire
     model: corelight-chronicle
     explore: events
     type: single_value
@@ -1280,8 +1283,8 @@
     explore: events
     listens_to_filters: []
     field: events.observer__namespace
-  - name: Traffic Direction(For TLS Versions)
-    title: Traffic Direction(For TLS Versions)
+  - name: Traffic Direction(Only for TLS Versions)
+    title: Traffic Direction(Only for TLS Versions)
     type: field_filter
     default_value: ''
     allow_multiple_values: true

--- a/dashboards/Secure_Channel_Insights.dashboard.lookml
+++ b/dashboards/Secure_Channel_Insights.dashboard.lookml
@@ -1,0 +1,1295 @@
+- dashboard: data_insights__secure_channel_insights
+  title: Data Insights - Secure Channel Insights
+  layout: newspaper
+  preferred_viewer: dashboards-next
+  description: ''
+  preferred_slug: JKazg3zmyCYMpNmAezQixa
+  elements:
+  - title: Less Secure Ciphers
+    name: Less Secure Ciphers
+    model: corelight-chronicle
+    explore: events
+    type: single_value
+    fields: [events.formatted_cipher_count]
+    filters:
+      events.metadata__product_event_type: ssl
+      events.match_cipher: 'Yes'
+    limit: 500
+    column_limit: 50
+    dynamic_fields:
+    - _kind_hint: measure
+      _type_hint: number
+      based_on: events.network__tls__cipher
+      expression: ''
+      label: Count of Network Tls Cipher
+      measure: count_of_network_tls_cipher
+      type: count_distinct
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    defaults_version: 1
+    hidden_pivots: {}
+    note_state: collapsed
+    note_display: above
+    note_text: Less Secure Ciphers
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 2
+    col: 12
+    width: 5
+    height: 3
+  - name: ''
+    type: text
+    title_text: ''
+    subtitle_text: ''
+    body_text: <h4 style="font-size:22px; margin-top:30px; font-style:normal;">Encrypted
+      Traffic Notables</h4>
+    row: 0
+    col: 0
+    width: 17
+    height: 2
+  - title: Less Secure Ciphers seen in the period
+    name: Less Secure Ciphers seen in the period
+    model: corelight-chronicle
+    explore: events
+    type: looker_grid
+    fields: [events.network__tls__cipher, events.last_target_ip, events__about__labels__uid__only.distinct_uid_only_count,
+      events.values_host_type_less_secure_cipher, events.values_direction_less_secure_cipher,
+      events.less_secure_cipher_seen_in_the_period_link]
+    filters:
+      events.metadata__product_event_type: ssl
+      events.match_cipher: 'Yes'
+      events.network__tls__cipher: "-NULL"
+    sorts: [events__about__labels__uid__only.distinct_uid_only_count desc]
+    limit: 5000
+    column_limit: 50
+    dynamic_fields:
+    - _kind_hint: measure
+      _type_hint: number
+      based_on: events.metadata__id
+      expression: ''
+      label: Count of Metadata ID
+      measure: count_of_metadata_id
+      type: count_distinct
+    - category: measure
+      expression: ''
+      label: Unique_Conns
+      based_on: events__about__labels__fuid__only.value
+      _kind_hint: measure
+      measure: unique_conns
+      type: count_distinct
+      _type_hint: number
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: false
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width:
+    series_labels:
+      events.network__tls__cipher: Cipher
+      events.last_target_ip: Dest IP
+      events__about__labels__uid__only.distinct_uid_only_count: Unique Conns
+      events.values_host_type_less_secure_cipher: Host Type
+      events.values_direction_less_secure_cipher: Direction
+      events.less_secure_cipher_seen_in_the_period_link: Raw Logs
+    series_cell_visualizations: {}
+    hidden_pivots: {}
+    defaults_version: 1
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 5
+    col: 12
+    width: 12
+    height: 6
+  - name: " (2)"
+    type: text
+    title_text: ''
+    subtitle_text: ''
+    body_text: '[{"type":"p","children":[{"text":"SSL/TLS sessions utilizing weak
+      cipher suites (eg. RC4) are easily decrypted. This traffic may indicate the
+      presence of old and/or unpatched resources on the network. It could also be
+      the result of a successful downgrade attack."}],"id":"m8tm6"}]'
+    rich_content_json: '{"format":"slate"}'
+    row: 2
+    col: 17
+    width: 7
+    height: 3
+  - title: Connections using Less Secure TLS Versions (< TLS12)
+    name: Connections using Less Secure TLS Versions (< TLS12)
+    model: corelight-chronicle
+    explore: events
+    type: single_value
+    fields: [events.formatted_connections_using_less_secure_tls_versions]
+    filters:
+      events.metadata__product_event_type: ssl
+      events__principal__ip.events__principal__ip: "-NULL"
+      events.version_status: "-%Secure%"
+    limit: 500
+    column_limit: 50
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: false
+    header_text_alignment: left
+    header_font_size: 12
+    rows_font_size: 12
+    hidden_pivots: {}
+    defaults_version: 1
+    note_state: collapsed
+    note_display: above
+    note_text: Connections using Less Secure TLS Versions (< TLS1.2)
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+      Traffic Direction(For TLS Versions): events.connection_type
+    row: 11
+    col: 0
+    width: 5
+    height: 3
+  - title: Network Evidence for All TLS versions seen
+    name: Network Evidence for All TLS versions seen
+    model: corelight-chronicle
+    explore: events
+    type: looker_grid
+    fields: [events.network__tls__version, events.version_status, events.connection_type,
+      events__about__labels__uid__only.formatted_uid_only_count, events.values_ip_classification,
+      events.all_tls_versions_link]
+    filters:
+      events.metadata__product_event_type: ssl
+      events__principal__ip.events__principal__ip: "-NULL"
+    sorts: [events__about__labels__uid__only.formatted_uid_only_count desc]
+    limit: 5000
+    column_limit: 50
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: false
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    column_order: ["$$$_row_numbers_$$$", events.network__tls__version, events.connection_type,
+      events__about__labels__uid__only.formatted_uid_only_count, events.values_ip_classification,
+      events.version_status]
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_labels:
+      events.version_status: Classification
+      events.connection_type: Traffic Direction
+      events.values_ip_classification: Responder Location
+      events__about__labels__uid__only.formatted_uid_only_count: Counter
+      events.network__tls__version: Version
+      events.network_evidence_for_all_tls_versions_link: Raw Logs
+      events.all_tls_versions_link: Raw Logs
+    series_cell_visualizations: {}
+    hidden_pivots: {}
+    defaults_version: 1
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+      Traffic Direction(For TLS Versions): events.connection_type
+    row: 14
+    col: 0
+    width: 12
+    height: 6
+  - title: Interactive Sessions and Keystrokes
+    name: Interactive Sessions and Keystrokes
+    model: corelight-chronicle
+    explore: events
+    type: single_value
+    fields: [events__about__labels__uid__only.distinct_uid_only_count]
+    filters:
+      events.metadata__product_event_type: ssh
+      events.inference: KS,AUTO
+    limit: 500
+    column_limit: 50
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    defaults_version: 1
+    note_state: collapsed
+    note_display: above
+    note_text: Interactive Sessions and Keystrokes
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 11
+    col: 12
+    width: 5
+    height: 3
+  - title: Network Evidence for Interactive Sessions and Keystrokes - SSH Inferences
+    name: Network Evidence for Interactive Sessions and Keystrokes - SSH Inferences
+    model: corelight-chronicle
+    explore: events
+    type: looker_grid
+    fields: [events__about__labels__uid__only.value, events__principal__ip.events__principal__ip,
+      events__target__ip.events__target__ip, events.inference, events__security_result.description,
+      events.metadata_id_count, events.interactive_sessions_and_keystrokes_link]
+    filters:
+      events.metadata__product_event_type: ssh
+      events.inference: KS,AUTO
+    sorts: [events.metadata_id_count desc]
+    limit: 5000
+    column_limit: 50
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: false
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    column_order: ["$$$_row_numbers_$$$", events__about__labels__uid__only.value,
+      events__principal__ip.events__principal__ip, events__target__ip.events__target__ip,
+      events.inference, events__security_result.description, events.metadata_id_count]
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width:
+    series_labels:
+      events__about__labels__uid__only.value: UID
+      events__target__ip.events__target__ip: Dest IP
+      events__principal__ip.events__principal__ip: Src IP
+      events__security_result.summary: Inference
+      events.metadata_id_count: Count
+      events__security_result.description: Description
+      events.network_evidence_for_interactive_sessions_and_keystrokes_link: Raw Logs
+      events.interactive_sessions_and_keystrokes_link: Raw Logs
+    series_cell_visualizations:
+      events__about__labels__uid__only.distinct_uid_only_count:
+        is_active: false
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    defaults_version: 1
+    hidden_pivots: {}
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 14
+    col: 12
+    width: 12
+    height: 6
+  - title: Network Evidence for Self Signed Internal Certificates
+    name: Network Evidence for Self Signed Internal Certificates
+    model: corelight-chronicle
+    explore: events
+    type: looker_grid
+    fields: [events.network__tls__client__server_name, events__target__ip.events__target__ip,
+      events__security_result__detection_fields_validation_status.value, is_ip_internal_external.dest_host_type,
+      events.values_traffic_direction, events.self_signed_certs_table_link]
+    filters:
+      events.metadata__product_event_type: ssl
+      events__security_result__detection_fields_validation_status.value: self signed
+        certificate
+      events__target__ip.events__target__ip: "-NULL"
+      is_ip_internal_external.is_dest_internal: 'true'
+      events.network__tls__client__server_name: "-NULL"
+    sorts: [events__target__ip.events__target__ip]
+    limit: 5000
+    column_limit: 50
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: false
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width:
+    series_labels:
+      events.network__tls__client__server_name: Subject
+      events__target__ip.events__target__ip: Destination
+      events__security_result__detection_fields_validation_status.value: Status
+      is_ip_internal_external.dest_host_type: Destination Host Type
+      events.traffic_direction: Traffic Direction
+      events.values_traffic_direction: Traffic Direction
+      events.self_signed_certs_table_link: Raw Logs
+    series_cell_visualizations:
+      events.self_signed_certs_table__link:
+        is_active: false
+    defaults_version: 1
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 23
+    col: 0
+    width: 12
+    height: 6
+  - title: Self Signed Certs
+    name: Self Signed Certs
+    model: corelight-chronicle
+    explore: events
+    type: single_value
+    fields: [events.formatted_self_signed_certs]
+    filters:
+      events.metadata__product_event_type: ssl
+      events__security_result__detection_fields_validation_status.value: self signed
+        certificate
+      is_ip_internal_external.is_dest_internal: 'true'
+    limit: 500
+    column_limit: 50
+    dynamic_fields:
+    - category: table_calculation
+      expression: sum(${count_of_network_tls_client_server_name})
+      label: Count
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: count
+      _type_hint: number
+      is_disabled: true
+    - _kind_hint: measure
+      _type_hint: number
+      based_on: events.network__tls__client__server_name
+      expression: ''
+      label: Count of Network Tls Client Server Name
+      measure: count_of_network_tls_client_server_name
+      type: count_distinct
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_labels:
+      events.network__tls__client__server_name: Subject
+      events__target__ip.events__target__ip: Destination
+      events__security_result__detection_fields_validation_status.value: Status
+      is_ip_internal_external.dest_host_type: Destination_Host_Type
+      events.traffic_direction: Traffic_Direction
+    defaults_version: 1
+    hidden_fields: []
+    hidden_pivots: {}
+    note_state: collapsed
+    note_display: above
+    note_text: Self Signed Certs
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 20
+    col: 0
+    width: 5
+    height: 3
+  - title: Possible File Uploaded
+    name: Possible File Uploaded
+    model: corelight-chronicle
+    explore: events
+    type: single_value
+    fields: [events__about__labels__uid__only.distinct_uid_only_count]
+    filters:
+      events.metadata__product_event_type: ssh
+      events.inference: SFD,LFD,SFU,LFU
+    limit: 500
+    column_limit: 50
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    defaults_version: 1
+    note_state: collapsed
+    note_display: above
+    note_text: Possible File Uploaded
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 20
+    col: 12
+    width: 5
+    height: 3
+  - title: Possible File Transfer
+    name: Possible File Transfer
+    model: corelight-chronicle
+    explore: events
+    type: looker_grid
+    fields: [events__about__labels__uid__only.value, events__principal__ip.events__principal__ip,
+      events__target__ip.events__target__ip, events.inference, events__security_result.description,
+      events.metadata_id_count, events.possible_file_transfer_link]
+    filters:
+      events.metadata__product_event_type: ssh
+      events.inference: SFD,LFD,SFU,LFU
+    sorts: [events.metadata_id_count desc]
+    limit: 5000
+    column_limit: 50
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: false
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width:
+    series_labels:
+      events__target__ip.events__target__ip: Dest IP
+      events__security_result.summary: inference
+      events__security_result.description: Description
+      events.metadata_id_count: Count
+      events.inference: Inference
+      events.possible_file_transfer_link: Raw Logs
+      events__about__labels__uid__only.value: UID
+      events__principal__ip.events__principal__ip: Src IP
+    series_cell_visualizations:
+      events.metadata_id_count:
+        is_active: false
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    defaults_version: 1
+    hidden_pivots: {}
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 23
+    col: 12
+    width: 12
+    height: 6
+  - title: Potential Security Risks
+    name: Potential Security Risks
+    model: corelight-chronicle
+    explore: events
+    type: single_value
+    fields: [events.formatted_potential_security_risks]
+    filters:
+      events.metadata__product_event_type: ssh
+      events.inference: SC,SP,SV,SA,AFR,BAN
+    limit: 500
+    column_limit: 50
+    dynamic_fields:
+    - category: table_calculation
+      expression: sum(${events.row_count})
+      label: count
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: count
+      _type_hint: number
+      is_disabled: true
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    hidden_fields: []
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: false
+    header_text_alignment: left
+    header_font_size: 12
+    rows_font_size: 12
+    defaults_version: 1
+    hidden_pivots: {}
+    note_state: collapsed
+    note_display: above
+    note_text: Potential Security Risks
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 29
+    col: 12
+    width: 5
+    height: 3
+  - title: SSH Inferences for Potential Security Risks
+    name: SSH Inferences for Potential Security Risks
+    model: corelight-chronicle
+    explore: events
+    type: looker_grid
+    fields: [events__about__labels__uid__only.value, events__principal__ip.events__principal__ip,
+      events__target__ip.events__target__ip, events.values_inference, events.formatted_metadata_id_count,
+      events.ssh_inferences_for_potential_security_risks_link]
+    filters:
+      events.metadata__product_event_type: ssh
+      events.inference: SC,SP,SV,SA,AFR,BAN
+    sorts: [events.formatted_metadata_id_count desc]
+    limit: 5000
+    column_limit: 50
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: false
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    column_order: ["$$$_row_numbers_$$$", events__about__labels__uid__only.value,
+      events__principal__ip.events__principal__ip, events__target__ip.events__target__ip,
+      events.formatted_metadata_id_count, events.inference]
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_labels:
+      events__about__labels__uid__only.value: UID
+      events__principal__ip.events__principal__ip: Src IP
+      events__target__ip.events__target__ip: Dest IP
+      events.inference: inference
+      events.formatted_metadata_id_count: Count
+      events.values_inference: Inferences
+      events.ssh_inferences_for_potentional_security_risks_link: Raw Logs
+      events.ssh_inferences_for_potential_security_risks_link: Raw Logs
+    series_cell_visualizations: {}
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    hidden_fields: []
+    defaults_version: 1
+    hidden_pivots: {}
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 32
+    col: 12
+    width: 12
+    height: 6
+  - title: Automated SSH Session Indicators
+    name: Automated SSH Session Indicators
+    model: corelight-chronicle
+    explore: events
+    type: single_value
+    fields: [events__about__labels__uid__only.formatted_uid_only_count]
+    filters:
+      events.metadata__product_event_type: ssh
+      events.inference: PKA,AUTO,KS,CTS
+    limit: 500
+    column_limit: 50
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_view_names: false
+    defaults_version: 1
+    note_state: collapsed
+    note_display: above
+    note_text: Automated SSH Session Indicators
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 38
+    col: 0
+    width: 5
+    height: 3
+  - title: SSH Session Inferences
+    name: SSH Session Inferences
+    model: corelight-chronicle
+    explore: events
+    type: looker_grid
+    fields: [events__about__labels__uid__only.value, events.values_prinicpal_ip, events.values_target_ip,
+      events.values_inference, events.metadata_id_count, events.values_description,
+      events.ssh_session_inferences_link]
+    filters:
+      events.metadata__product_event_type: ssh
+      events.inference: PKA,AUTO,KS,CTS
+    sorts: [events.values_prinicpal_ip desc 0]
+    limit: 5000
+    column_limit: 50
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: false
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_labels:
+      events__about__labels__uid__only.value: UID
+      events.values_prinicpal_ip: Src IPs
+      events.values_target_ip: Dest IPs
+      events.values_inference: Inferences
+      events.metadata_id_count: Count
+      events.values_description: Description
+      events.ssh_session_inferences_link: Raw Logs
+    series_cell_visualizations: {}
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    defaults_version: 1
+    hidden_pivots: {}
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 41
+    col: 0
+    width: 12
+    height: 6
+  - title: Advanced Threat Indicators
+    name: Advanced Threat Indicators
+    model: corelight-chronicle
+    explore: events
+    type: single_value
+    fields: [events__about__labels__uid__only.formatted_uid_only_count]
+    filters:
+      events.metadata__product_event_type: ssh
+      events.inference: ABP,RSP,RSI,RSIA,RSL,RSK
+    limit: 500
+    column_limit: 50
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: false
+    header_text_alignment: left
+    header_font_size: 12
+    rows_font_size: 12
+    defaults_version: 1
+    note_state: collapsed
+    note_display: above
+    note_text: Advanced Threat Indicators
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 38
+    col: 12
+    width: 5
+    height: 3
+  - title: SSH Advanced Threats Infereces
+    name: SSH Advanced Threats Infereces
+    model: corelight-chronicle
+    explore: events
+    type: looker_grid
+    fields: [events__about__labels__uid__only.value, events__principal__ip.events__principal__ip,
+      events__target__ip.events__target__ip, events.inference, events.metadata_id_count,
+      events__security_result.description, events.ssh_advance_threat_inferences_link]
+    filters:
+      events.metadata__product_event_type: ssh
+      events.inference: ABP,RSP,RSI,RSIA,RSL,RSK
+    sorts: [events.metadata_id_count desc 0]
+    limit: 5000
+    column_limit: 50
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: false
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    column_order: ["$$$_row_numbers_$$$", events__about__labels__uid__only.value,
+      events__principal__ip.events__principal__ip, events__target__ip.events__target__ip,
+      events.inference, events.metadata_id_count, events__security_result.description]
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width:
+    series_labels:
+      events__about__labels__uid__only.value: UID
+      events__principal__ip.events__principal__ip: Src IP
+      events__target__ip.events__target__ip: Dest IP
+      events.inference: Inference
+      events__security_result.description: Description
+      events.metadata_id_count: Count
+      events.ssh_advance_threat_inferences_link: Raw Logs
+    series_cell_visualizations:
+      events.metadata_id_count:
+        is_active: false
+    hidden_pivots: {}
+    defaults_version: 1
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 41
+    col: 12
+    width: 12
+    height: 6
+  - name: " (Copy 2)"
+    type: text
+    title_text: " (Copy 2)"
+    subtitle_text: ''
+    body_text: '[{"type":"p","children":[{"text":"Connections employing TLS versions
+      older than 1.2 are recognized as less secure, presenting a higher risk of being
+      compromised. These outdated protocols may indicate legacy systems with configurations
+      that are not aligned with modern security standards."}],"id":"e9y2q"}]'
+    rich_content_json: '{"format":"slate"}'
+    row: 11
+    col: 5
+    width: 7
+    height: 3
+  - name: " (Copy 7)"
+    type: text
+    title_text: " (Copy 7)"
+    subtitle_text: ''
+    body_text: '[{"type":"p","children":[{"text":"This use case tracks SSH file transfer
+      activity (inferences SFD, LFD, SFU, LFU). It uncovers potential data exfiltration
+      by attackers or the introduction of malicious files. Focus on file names, sizes,
+      unusual source IPs, and sensitive destination systems."}],"id":"26leb"}]'
+    rich_content_json: '{"format":"slate"}'
+    row: 20
+    col: 17
+    width: 7
+    height: 3
+  - name: " (Copy 8)"
+    type: text
+    title_text: " (Copy 8)"
+    subtitle_text: ''
+    body_text: '[{"type":"p","children":[{"text":"A SSL certificate that is about
+      to expire (default window is 30 days) was observed. Expiration of an SSL certificate
+      may result in unexpected behaviour such as refused network connections or unencrypted
+      network traffic."}],"id":"1lcjl"}]'
+    rich_content_json: '{"format":"slate"}'
+    row: 29
+    col: 5
+    width: 7
+    height: 3
+  - name: " (Copy 9)"
+    type: text
+    title_text: " (Copy 9)"
+    subtitle_text: ''
+    body_text: '[{"type":"p","children":[{"text":"Helps to identify potential advanced
+      threat indicators such as Client Authentication Bypass (ABP) and Reverse SSH
+      tunneling activities (RSP, RSI, RSIA, RSL, RSK) for in-depth investigation."}],"id":"qwgng"}]'
+    rich_content_json: '{"format":"slate"}'
+    row: 38
+    col: 17
+    width: 7
+    height: 3
+  - name: " (Copy 3)"
+    type: text
+    title_text: " (Copy 3)"
+    subtitle_text: ''
+    body_text: '[{"type":"p","children":[{"text":"Monitors for signs of scanning (SC,
+      SP, SV, SA), banner messages (BAN), and agent forwarding (AFR) for compliance
+      and security risk identification."}],"id":"5wr63"}]'
+    rich_content_json: '{"format":"slate"}'
+    row: 29
+    col: 17
+    width: 7
+    height: 3
+  - name: " (Copy 4)"
+    type: text
+    title_text: " (Copy 4)"
+    subtitle_text: ''
+    body_text: '[{"type":"p","children":[{"text":"Highlight interactive sessions (KS)
+      and automated interactions (AUTO) to understand the nature of SSH traffic —
+      manual vs. automated."}],"id":"icocm"}]'
+    rich_content_json: '{"format":"slate"}'
+    row: 11
+    col: 17
+    width: 7
+    height: 3
+  - name: " (Copy)"
+    type: text
+    title_text: " (Copy)"
+    subtitle_text: ''
+    body_text: '[{"type":"p","children":[{"text":"SSL/TLS sessions utilizing weak
+      keys are vulnerable to cryptographic attacks. This traffic may indicate the
+      presence of old and/or unpatched resources on the network. It could also be
+      the result of a successful downgrade attack."}],"id":"706jz"}]'
+    rich_content_json: '{"format":"slate"}'
+    row: 2
+    col: 5
+    width: 7
+    height: 3
+  - name: " (Copy 5)"
+    type: text
+    title_text: " (Copy 5)"
+    subtitle_text: ''
+    body_text: '[{"type":"p","children":[{"text":"This dashboard panel identifies
+      self-signed certificates in use within internal networks, highlighting a key
+      security concern due to their lack of third-party validation. Addressing this
+      issue by transitioning to certificates from trusted authorities enhances network
+      security and trustworthiness."}],"id":"xx8st"}]'
+    rich_content_json: '{"format":"slate"}'
+    row: 20
+    col: 5
+    width: 7
+    height: 3
+  - name: " (Copy 6)"
+    type: text
+    title_text: " (Copy 6)"
+    subtitle_text: ''
+    body_text: '[{"type":"p","children":[{"text":"Tracks automated SSH sessions to
+      enhance security and operational efficiency, highlighting potential risks and
+      compliance issues. It identifies anomalies and unauthorized activities, ensuring
+      that automation tools are used securely and efficiently. This tool is crucial
+      for SOC analysts to monitor for security breaches and optimize system management."}],"id":"vhu4j"}]'
+    rich_content_json: '{"format":"slate"}'
+    row: 38
+    col: 5
+    width: 7
+    height: 3
+  - title: Network Evidence for Weak Key Length Certs
+    name: Network Evidence for Weak Key Length Certs
+    model: corelight-chronicle
+    explore: events
+    type: looker_grid
+    fields: [events.network__tls__client__server_name, events__target__ip.events__target__ip,
+      events.target__port, x509_events_only.certificate_key_length, is_ip_internal_external.dest_host_type,
+      events.metadata_id_count, events.weak_key_length_certs_link]
+    filters:
+      events.metadata__product_event_type: ssl
+      x509_events_only.certificate_key_length: "<2048"
+      is_ip_internal_external.dest_host_type: Internal
+      events.connection_type: ''
+    sorts: [events.network__tls__client__server_name desc]
+    limit: 5000
+    column_limit: 50
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: false
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width:
+    series_labels:
+      events.network__tls__client__server_name: Server Name
+      events__target__ip.events__target__ip: Dest Host
+      events.target__port: Dest Port
+      x509_events_only.certificate_key_length: Key Length
+      is_ip_internal_external.dest_host_type: Host Type
+      events.metadata_id_count: Count
+      events.network_evidence_for_weak_key_length_certs_link: Raw Logs
+      events.weak_key_length_certs_link: Raw Logs
+    series_cell_visualizations:
+      events.metadata_id_count:
+        is_active: false
+    defaults_version: 1
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 5
+    col: 0
+    width: 12
+    height: 6
+  - title: Weak Certs Used Internally
+    name: Weak Certs Used Internally
+    model: corelight-chronicle
+    explore: events
+    type: single_value
+    fields: [count_of_fingerprint]
+    filters:
+      events.metadata__product_event_type: ssl
+      x509_events_only.certificate_key_length: "<2048"
+      is_ip_internal_external.dest_host_type: Internal
+    limit: 500
+    column_limit: 50
+    dynamic_fields:
+    - _kind_hint: measure
+      _type_hint: number
+      based_on: x509_events_only.certificate_key_length
+      expression: ''
+      label: Count of Certificate Key Length
+      measure: count_of_certificate_key_length
+      type: count_distinct
+    - _kind_hint: measure
+      _type_hint: number
+      based_on: x509_events_only.fingerprint
+      expression: ''
+      label: Count of Fingerprint
+      measure: count_of_fingerprint
+      type: count_distinct
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    truncate_header: false
+    size_to_fit: true
+    minimum_column_width: 75
+    series_labels:
+      events.network__tls__client__server_name: Server Name
+      events__target__ip.events__target__ip: Dest IP
+      events.target__port: Dest Port
+      x509_events_only.certificate_key_length: Key Length
+      is_ip_internal_external.dest_host_type: Host Type
+      events.metadata_id_count: Count
+    series_cell_visualizations:
+      events.metadata_id_count:
+        is_active: false
+    table_theme: white
+    limit_displayed_rows: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    hide_totals: false
+    hide_row_totals: false
+    defaults_version: 1
+    hidden_pivots: {}
+    note_state: collapsed
+    note_display: above
+    note_text: Weak Certs. Used Internally
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 2
+    col: 0
+    width: 5
+    height: 3
+  - title: Network Evidence for Self Signed Internal Certificates
+    name: Network Evidence for Self Signed Internal Certificates (2)
+    model: corelight-chronicle
+    explore: events
+    type: looker_grid
+    fields: [x509_events_only.subject, events__target__ip.events__target__ip, events.values_target_port,
+      x509_events_only.max_cert_not_valid_after, x509_events_only.max_cert_day_to_expire,
+      events.cert_about_to_expire_table_link]
+    filters:
+      events.metadata__product_event_type: ssl
+      is_ip_internal_external.is_dest_internal: 'true'
+      x509_events_only.cert_day_to_expire: "(0,30)"
+    sorts: [x509_events_only.max_cert_day_to_expire desc]
+    limit: 5000
+    column_limit: 50
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: false
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_labels:
+      x509_events_only.subject: Subject
+      events__target__ip.events__target__ip: Host
+      events.values_target_port: Port
+      x509_events_only.values_cert_not_valid_after: Not Valid After
+      x509_events_only.values_cert_day_to_expire: Days to Expire
+      events.cert_about_to_expire_table_link: Raw Logs
+      x509_events_only.max_cert_not_valid_after: Not Valid After
+      x509_events_only.max_cert_day_to_expire: Days to Expire
+    series_cell_visualizations: {}
+    defaults_version: 1
+    hidden_pivots: {}
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 32
+    col: 0
+    width: 12
+    height: 6
+  - title: Certificates about to Expire
+    name: Certificates about to Expire
+    model: corelight-chronicle
+    explore: events
+    type: single_value
+    fields: [events.formatted_certificates_about_to_expire]
+    filters:
+      events.metadata__product_event_type: ssl
+      is_ip_internal_external.is_dest_internal: 'true'
+      x509_events_only.cert_day_to_expire: "(0,30)"
+    limit: 500
+    column_limit: 50
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: false
+    header_text_alignment: left
+    header_font_size: 12
+    rows_font_size: 12
+    defaults_version: 1
+    hidden_pivots: {}
+    note_state: collapsed
+    note_display: above
+    note_text: Certificates about to Expire
+    listen:
+      Global Time Restriction: events.event_timestamp_time
+      Sensor: events.observer__hostname
+      Namespace: events.observer__namespace
+    row: 29
+    col: 0
+    width: 5
+    height: 3
+  - type: button
+    name: button_1903
+    rich_content_json: '{"text":"For Further Investigations -- SSH Inferences","description":"","newTab":true,"alignment":"center","size":"medium","style":"FILLED","color":"#1A73E8","href":"/dashboards/corelight-chronicle::ssh_inferences_overview?Event+Type=ssh&Time+Range=24+hour&SSH+Inferences="}'
+    row: 0
+    col: 17
+    width: 7
+    height: 2
+  filters:
+  - name: Global Time Restriction
+    title: Global Time Restriction
+    type: field_filter
+    default_value: 24 hour
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: advanced
+      display: popover
+      options: []
+    model: corelight-chronicle
+    explore: events
+    listens_to_filters: []
+    field: events.event_timestamp_time
+  - name: Sensor
+    title: Sensor
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: inline
+    model: corelight-chronicle
+    explore: events
+    listens_to_filters: []
+    field: events.observer__hostname
+  - name: Namespace
+    title: Namespace
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: inline
+      options: []
+    model: corelight-chronicle
+    explore: events
+    listens_to_filters: []
+    field: events.observer__namespace
+  - name: Traffic Direction(For TLS Versions)
+    title: Traffic Direction(For TLS Versions)
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: inline
+    model: corelight-chronicle
+    explore: events
+    listens_to_filters: []
+    field: events.connection_type

--- a/explores/events.explore.lkml
+++ b/explores/events.explore.lkml
@@ -767,6 +767,13 @@ explore: events {
     sql_on: ${events__about__labels__uid.value} = ${http_group_by_uid_src_dest.conn_uids} ;;
     relationship: one_to_one
   }
+  #Secure Channel Insights
+  join: is_ip_internal_external {
+    view_label: "Events: UID with filtered on conn type event"
+    type: left_outer
+    sql_on: ${events__about__labels__uid__only.value} = ${is_ip_internal_external.conn_uids} ;;
+    relationship: one_to_one
+  }
   #data-exploration-http
   join: events__about__labels__status__msg {
     view_label: "Events: About Labels status msg"
@@ -9318,4 +9325,16 @@ explore: events {
     relationship: one_to_many
   }
 
+  join: events__target__labels_cert_chain_fps {
+    view_label: "Events: Target Labels Cert Chain FPS"
+    sql: LEFT JOIN UNNEST(${events.target__labels}) as events__target__labels_cert_chain_fps ON ${events__target__labels_cert_chain_fps.key} = 'cert_chain_fps';;
+    fields: [events__target__labels_cert_chain_fps.value]
+    relationship: one_to_many
+  }
+  #Secure Channel Insights
+  join: x509_events_only {
+    type: inner
+    sql_on: ${x509_events_only.fingerprint} = ${events__target__labels_cert_chain_fps.value};;
+    relationship: one_to_many
+  }
 }

--- a/views/events.view.lkml
+++ b/views/events.view.lkml
@@ -1259,6 +1259,29 @@ view: events {
     group_label: "Network Tls"
     group_item_label: "Cipher"
   }
+  #Secure Channel Insights - Less Secure Ciphers seen in the period
+  measure: cipher_count {
+    type: count_distinct
+    sql: ${network__tls__cipher} ;;
+    group_label: "Network Tls"
+    group_item_label: "Cipher Count"
+  }
+  #Secure Channel Insights - Less Secure Ciphers seen in the period
+  measure: formatted_cipher_count {
+    type: string
+    sql:
+    CASE
+        WHEN ${cipher_count} > 999 THEN
+            CASE
+                WHEN ROUND(${cipher_count}/1000)*1000 = ${cipher_count} THEN CONCAT(CAST(ROUND(${cipher_count}/1000) AS STRING), 'K')
+                WHEN MOD(${cipher_count}, 1000) <= 100 THEN CONCAT(CAST(FLOOR(${cipher_count}/1000) AS STRING), 'K')
+                ELSE CONCAT(CAST(ROUND(${cipher_count}/1000, 1) AS STRING), 'K')
+            END
+        ELSE CAST(${cipher_count} AS STRING)
+    END;;
+    group_label: "Network Tls"
+    group_item_label: "Cipher Formatted Count"
+  }
   dimension: network__tls__client__certificate__issuer {
     type: string
     sql: ${TABLE}.network.tls.client.certificate.issuer ;;
@@ -31150,6 +31173,353 @@ view: events {
       label: "View in Chronicle"
       url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{ events.metadata__vendor_name }}\" AND {% if auth_result._value == 'Failure' %} about.labels[\"auth_success\"]=\"false\"{% else %} about.labels[\"auth_success\"]=\"true\" {% endif %} {% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}{% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
     }
+  }
+
+  #Secure Channel Insights - Less Secure Ciphers
+  dimension: match_cipher {
+    type: yesno
+    sql: REGEXP_CONTAINS(${network__tls__cipher}, r"(RC4|DES|3DES|MD5|NULL|EXPORT)") OR ${network__tls__cipher} IS NULL;;
+  }
+
+  #Secure Channel Insights - Less Secure Ciphers seen in the period
+  measure: last_target_ip {
+    type: string
+    sql: ARRAY_AGG(${events__target__ip.events__target__ip} ORDER BY ${event_timestamp_time} DESC LIMIT 1)[OFFSET(0)] ;;
+  }
+
+  #Secure Channel Insights - Less Secure Ciphers seen in the period
+  dimension: direction_less_secure_cipher {
+    type: string
+    sql: CASE
+            WHEN ${is_ip_internal_external.is_src_internal} = 'true' AND ${is_ip_internal_external.is_dest_internal} = 'false' THEN 'Outbound'
+            ELSE 'Inbound'
+         END;;
+  }
+
+  #Secure Channel Insights - Less Secure Ciphers seen in the period
+  measure: values_direction_less_secure_cipher {
+    type: string
+    sql: ARRAY_TO_STRING(ARRAY_AGG(DISTINCT ${direction_less_secure_cipher} IGNORE NULLS), ',');;
+  }
+
+  #Secure Channel Insights - Less Secure Ciphers seen in the period
+  measure: values_host_type_less_secure_cipher {
+    type: string
+    sql: ARRAY_TO_STRING(ARRAY_AGG(DISTINCT ${is_ip_internal_external.src_host_type} IGNORE NULLS), ',') ;;
+  }
+
+  #Secure Channel Insights - Connections using Less Secure TLS Versions (< TLS1.2)
+  dimension: tls_version_dest_internal {
+    type: string
+    sql: CASE
+            WHEN ${is_ip_internal_external.is_dest_internal} = 'true' THEN 'true'
+            ELSE 'false'
+         END;;
+
+  }
+  #Secure Channel Insights - Connections using Less Secure TLS Versions (< TLS1.2)
+  dimension: tls_version_src_internal {
+    type: string
+    sql: CASE
+            WHEN ${is_ip_internal_external.is_src_internal} = 'true' THEN 'true'
+            ELSE 'false'
+         END;;
+  }
+
+  #Secure Channel Insights - Connections using Less Secure TLS Versions (< TLS1.2)
+  dimension: connection_type {
+    type: string
+    sql: CASE
+            WHEN ${tls_version_src_internal} = 'true' AND ${tls_version_dest_internal} = 'false' THEN 'Outbound'
+            WHEN ${tls_version_src_internal} = 'false' AND ${tls_version_dest_internal} = 'true' THEN 'Inbound'
+            WHEN ${tls_version_src_internal} = 'true' AND ${tls_version_dest_internal} = 'true' THEN 'Internal'
+            WHEN ${tls_version_src_internal} = 'false' AND ${tls_version_dest_internal} = 'false' THEN 'EEther'
+         END;;
+  }
+
+  #Secure Channel Insights - Network Evidence for All TLS versions seen
+  measure: values_ip_classification {
+    type: string
+    sql:  ARRAY_TO_STRING(ARRAY_AGG(DISTINCT ${is_ip_internal_external.dest_host_type} IGNORE NULLS), ',');;
+  }
+
+  #Secure Channel Insights - Network Evidence for Self Signed Internal Certificates
+  dimension: traffic_direction {
+    type: string
+    sql: CASE
+            WHEN ${is_ip_internal_external.src_host_type} = 'Internal' AND ${is_ip_internal_external.dest_host_type} = 'External' THEN 'Outbound'
+            WHEN ${is_ip_internal_external.src_host_type} = 'External' AND ${is_ip_internal_external.dest_host_type} = 'Internal' THEN 'Inbound'
+            WHEN ${is_ip_internal_external.src_host_type} = 'Internal' AND ${is_ip_internal_external.dest_host_type} = 'Internal' THEN 'East-West'
+            WHEN ${is_ip_internal_external.src_host_type} = 'External' AND ${is_ip_internal_external.dest_host_type} = 'External' THEN 'Ether'
+            ELSE 'Undefined'
+         END;;
+  }
+
+  #Secure Channel Insights - Network Evidence for Self Signed Internal Certificates
+  measure: values_traffic_direction {
+    type: string
+    sql:  ARRAY_TO_STRING(ARRAY_AGG(DISTINCT ${traffic_direction} IGNORE NULLS), ',');;
+  }
+
+  #Secure Channel Insights
+  dimension: inference {
+    type: string
+    sql: CASE WHEN ${events__security_result.summary} = 'Client Authentication Bypass' THEN 'ABP'
+              WHEN ${events__security_result.summary} = 'SSH Agent Forwarding Requested' THEN 'AFR'
+              WHEN ${events__security_result.summary} = 'Automated Password Authentication' THEN 'APWA'
+              WHEN ${events__security_result.summary} = 'Automated Interaction' THEN 'AUTO'
+              WHEN ${events__security_result.summary} = 'Server Banner' THEN 'BAN'
+              WHEN ${events__security_result.summary} = 'Client Brute Force Guessing' THEN 'BF'
+              WHEN ${events__security_result.summary} = 'Client Brute Force Success' THEN 'BFS'
+              WHEN ${events__security_result.summary} = 'Client Trusted Server' THEN 'CTS'
+              WHEN ${events__security_result.summary} = 'Client Untrusted Server' THEN 'CUS'
+              WHEN ${events__security_result.summary} = 'Interactive Password Authentication' THEN 'IPWA'
+              WHEN ${events__security_result.summary} = 'Keystrokes' THEN 'KS'
+              WHEN ${events__security_result.summary} = 'Large Client File Donwload' THEN 'LFD'
+              WHEN ${events__security_result.summary} = 'Large Client File Upload' THEN 'LFU'
+              WHEN ${events__security_result.summary} = 'Multifactor Authentication' THEN 'MFA'
+              WHEN ${events__security_result.summary} = 'None Authentication' THEN 'NA'
+              WHEN ${events__security_result.summary} = 'No Remote Command' THEN 'NRC'
+              WHEN ${events__security_result.summary} = 'Public Key Authentication' THEN 'PKA'
+              WHEN ${events__security_result.summary} = 'Reverse SSH Initiated' THEN 'RSI'
+              WHEN ${events__security_result.summary} = 'Reverse SSH Initiated Automate' THEN 'RSIA'
+              WHEN ${events__security_result.summary} = 'Reverse SSH Keystrokes' THEN 'RSK'
+              WHEN ${events__security_result.summary} = 'Reverse SSH Logged In' THEN 'RSL'
+              WHEN ${events__security_result.summary} = 'Reverse SSH Providioned' THEN 'RSP'
+              WHEN ${events__security_result.summary} = 'Authentication Scanning' THEN 'SA'
+              WHEN ${events__security_result.summary} = 'Capabilities Scanning' THEN 'SC'
+              WHEN ${events__security_result.summary} = 'Small Client File Download' THEN 'SFD'
+              WHEN ${events__security_result.summary} = 'Small Client File Upload' THEN 'SFU'
+              WHEN ${events__security_result.summary} = 'Other Scanning' THEN 'SP'
+              WHEN ${events__security_result.summary} = 'Version Scanning' THEN 'SV'
+              WHEN ${events__security_result.summary} = 'Unknown Authentication' THEN 'UA'
+              END ;;
+  }
+
+  #Secure Channel Insights
+  measure: values_inference {
+    type: string
+    sql:  ARRAY_TO_STRING(ARRAY_AGG(DISTINCT ${inference} IGNORE NULLS), ',');;
+  }
+
+  #Secure Channel Insights - Automated SSH Session Indicators
+  measure: values_target_ip {
+    type: string
+    sql:  ARRAY_TO_STRING(ARRAY_AGG(DISTINCT ${events__target__ip.events__target__ip} IGNORE NULLS), ',');;
+  }
+
+  #Secure Channel Insights - Automated SSH Session Indicators
+  measure: values_prinicpal_ip {
+    type: string
+    sql:  ARRAY_TO_STRING(ARRAY_AGG(DISTINCT ${events__principal__ip.events__principal__ip} IGNORE NULLS), ',');;
+  }
+
+  #Secure Channel Insights - Certificates about to Expire
+  measure: values_target_port {
+    type: string
+    sql:  ARRAY_TO_STRING(ARRAY_AGG(DISTINCT CAST(${target__port} AS STRING) IGNORE NULLS), ',');;
+  }
+
+  #Secure Channel Insights - Automated SSH Session Indicators
+  measure: values_description {
+    type: string
+    sql:  ARRAY_TO_STRING(ARRAY_AGG(DISTINCT ${events__security_result.description} IGNORE NULLS), ',');;
+  }
+
+  #Secure Channel Insights - Connections using Less Secure TLS Versions
+  measure: connections_using_less_secure_tls_versions {
+    type: count_distinct
+    sql:CONCAT(${events__principal__ip.events__principal__ip}, ${events__target__ip.events__target__ip}, ${events__about__labels__uid__only.value});;
+  }
+
+  #Secure Channel Insights - Connections using Less Secure TLS Versions
+  measure: formatted_connections_using_less_secure_tls_versions {
+    type: string
+    sql:
+    CASE
+        WHEN ${connections_using_less_secure_tls_versions} > 999 THEN
+            CASE
+                WHEN ROUND(${connections_using_less_secure_tls_versions}/1000)*1000 = ${connections_using_less_secure_tls_versions} THEN CONCAT(CAST(ROUND(${connections_using_less_secure_tls_versions}/1000) AS STRING), 'K')
+                WHEN MOD(${connections_using_less_secure_tls_versions}, 1000) <= 100 THEN CONCAT(CAST(FLOOR(${connections_using_less_secure_tls_versions}/1000) AS STRING), 'K')
+                ELSE CONCAT(CAST(ROUND(${connections_using_less_secure_tls_versions}/1000, 1) AS STRING), 'K')
+            END
+        ELSE CAST(${connections_using_less_secure_tls_versions} AS STRING)
+    END;;
+  }
+
+  #Secure Channel Insights - Interactive Sessions Keystrokes
+  measure: interactive_sessions_keystrokes {
+    type: count_distinct
+    sql:CONCAT(${events__about__labels__uid__only.value}, ${events__principal__ip.events__principal__ip}, ${events__target__ip.events__target__ip},${inference});;
+  }
+
+  #Secure Channel Insights - Self Signed Certs
+  measure: self_signed_certs {
+    type: count_distinct
+    sql: CONCAT(${network__tls__client__server_name}, ${events__target__ip.events__target__ip});;
+  }
+
+  #Secure Channel Insights - Self Signed Certs
+  measure: formatted_self_signed_certs {
+    type: string
+    sql:
+    CASE
+        WHEN ${self_signed_certs} > 999 THEN
+            CASE
+                WHEN ROUND(${self_signed_certs}/1000)*1000 = ${self_signed_certs} THEN CONCAT(CAST(ROUND(${self_signed_certs}/1000) AS STRING), 'K')
+                WHEN MOD(${self_signed_certs}, 1000) <= 100 THEN CONCAT(CAST(FLOOR(${self_signed_certs}/1000) AS STRING), 'K')
+                ELSE CONCAT(CAST(ROUND(${self_signed_certs}/1000, 1) AS STRING), 'K')
+            END
+        ELSE CAST(${self_signed_certs} AS STRING)
+    END;;
+  }
+
+  #Secure Channel Insights - Potential Security Risks
+  measure: potential_security_risks {
+    type: count_distinct
+    sql: CONCAT(${events__about__labels__uid__only.value}, ${events__principal__ip.events__principal__ip}, ${events__target__ip.events__target__ip});;
+  }
+
+  #Secure Channel Insights - Potential Security Risks
+  measure: formatted_potential_security_risks {
+    type: string
+    sql:
+    CASE
+        WHEN ${potential_security_risks} > 999 THEN
+            CASE
+                WHEN ROUND(${potential_security_risks}/1000)*1000 = ${potential_security_risks} THEN CONCAT(CAST(ROUND(${potential_security_risks}/1000) AS STRING), 'K')
+                WHEN MOD(${potential_security_risks}, 1000) <= 100 THEN CONCAT(CAST(FLOOR(${potential_security_risks}/1000) AS STRING), 'K')
+                ELSE CONCAT(CAST(ROUND(${potential_security_risks}/1000, 1) AS STRING), 'K')
+            END
+        ELSE CAST(${potential_security_risks} AS STRING)
+    END;;
+  }
+
+  #Secure Channel Insights - Certificates about to Expire
+  measure: certificates_about_to_expire {
+    type: count_distinct
+    sql:CONCAT(${x509_events_only.subject}, ${events__target__ip.events__target__ip});;
+  }
+
+  #Secure Channel Insights - Certificates about to Expire
+  measure: formatted_certificates_about_to_expire {
+    type: string
+    sql:
+    CASE
+        WHEN ${certificates_about_to_expire} > 999 THEN
+            CASE
+                WHEN ROUND(${certificates_about_to_expire}/1000)*1000 = ${certificates_about_to_expire} THEN CONCAT(CAST(ROUND(${certificates_about_to_expire}/1000) AS STRING), 'K')
+                WHEN MOD(${certificates_about_to_expire}, 1000) <= 100 THEN CONCAT(CAST(FLOOR(${certificates_about_to_expire}/1000) AS STRING), 'K')
+                ELSE CONCAT(CAST(ROUND(${certificates_about_to_expire}/1000, 1) AS STRING), 'K')
+            END
+        ELSE CAST(${certificates_about_to_expire} AS STRING)
+    END;;
+  }
+
+  #Secure Channel Insights - Weak Certs. Used Internally
+  measure: weak_certs_used_internally {
+    type: count_distinct
+    sql:CONCAT(${network__tls__client__server_name}, ${events__target__ip.events__target__ip}, ${target__port}, ${x509_events_only.certificate_key_length}, ${is_ip_internal_external.dest_host_type});;
+  }
+
+  #Secure Channel Insights - Network Evidence for Weak Key Length Certs
+  measure: weak_key_length_certs_link {
+    type: count
+    link: {
+      label: "View in Chronicle"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND network.tls.client.server_name=\"{{ network__tls__client__server_name }}\" AND target.ip=\"{{events__target__ip.events__target__ip}}\" AND target.port={{ target__port }}{% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+    }
+    html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
+  }
+
+  #Secure Channel Insights - Less Secure Ciphers seen in the period
+  measure: less_secure_cipher_seen_in_the_period_link {
+    type: count
+    link: {
+      label: "View in Chronicle"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND network.tls.cipher=\"{{ network__tls__cipher | url_encode }}\" {% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+    }
+    html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
+  }
+
+  #Secure Channel Insights - Network Evidence for All TLS versions seen
+  measure: all_tls_versions_link {
+    type: count
+    link: {
+      label: "View in Chronicle"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND network.tls.version=\"{{ network__tls__version | url_encode }}\" AND target.ip != \"\" {% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+    }
+    html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
+  }
+
+  #Secure Channel Insights - Network Evidence for Interactive Sessions and Keystrokes - SSH Inferences
+  measure: interactive_sessions_and_keystrokes_link {
+    type: count
+    link: {
+      label: "View in Chronicle"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND about.labels[\"uid\"]=\"{{ events__about__labels__uid__only.value }}\" AND principal.ip=\"{{ events__principal__ip.events__principal__ip }}\" AND target.ip=\"{{ events__target__ip.events__target__ip }}\" AND security_result.summary=\"{{ events__security_result.summary | url_encode }}\"{% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+    }
+    html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
+  }
+
+  #Secure Channel Insights - Network Evidence for Self Signed Internal Certificates - Self Signed Certs
+  measure: self_signed_certs_table_link {
+    type: count
+    link: {
+      label: "View in Chronicle"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND network.tls.client.server_name=\"{{ network__tls__client__server_name }}\" AND target.ip=\"{{ events__target__ip.events__target__ip }}\" AND security_result.detection_fields[\"validation_status\"]=\"self signed certificate\"{% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+    }
+    html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
+  }
+
+  #Secure Channel Insights - Possible File Transfer
+  measure: possible_file_transfer_link {
+    type: count
+    link: {
+      label: "View in Chronicle"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND about.labels[\"uid\"]=\"{{ events__about__labels__uid__only.value }}\" AND principal.ip=\"{{ events__principal__ip.events__principal__ip }}\" AND target.ip=\"{{ events__target__ip.events__target__ip }}\" AND security_result.summary=\"{{ events__security_result.summary }}\"{% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+    }
+    html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
+  }
+
+  #Secure Channel Insights - Network Evidence for Self Signed Internal Certificates - Certificates About to Expire
+  measure: cert_about_to_expire_table_link {
+    type: count
+    link: {
+      label: "View in Chronicle"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND network.tls.client.server_name=\"{{ network__tls__client__server_name }}\" AND target.ip=\"{{events__target__ip.events__target__ip}}\"{% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+    }
+    html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
+  }
+
+  #Secure Channel Insights - SSH Inferences for Potential Security Risks
+  measure: ssh_inferences_for_potential_security_risks_link {
+    type: count
+    link: {
+      label: "View in Chronicle"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND about.labels[\"uid\"]=\"{{ events__about__labels__uid__only.value }}\" AND principal.ip=\"{{events__principal__ip.events__principal__ip}}\" AND target.ip=\"{{events__target__ip.events__target__ip}}\" AND (security_result.summary=\"Capabilities Scanning\" OR security_result.summary=\"Other Scanning\" OR security_result.summary=\"Version Scanning\" OR security_result.summary=\"Authentication Scanning\" OR security_result.summary=\"SSH Agent Forwarding Requested\" OR security_result.summary=\"Server Banner\"){% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+    }
+    html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
+  }
+
+  #Secure Channel Insights - SSH Session Inferences
+  measure: ssh_session_inferences_link {
+    type: count
+    link: {
+      label: "View in Chronicle"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND about.labels[\"uid\"]=\"{{ events__about__labels__uid__only.value }}\" AND (security_result.summary=\"Public Key Authentication\" OR security_result.summary=\"Automated Interaction\" OR security_result.summary=\"Keystrokes\" OR security_result.summary=\"Client Trusted Server\"){% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+    }
+    html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
+  }
+
+  #Secure Channel Insights - SSH Advanced Threats Infereces
+  measure: ssh_advance_threat_inferences_link {
+    type: count
+    link: {
+      label: "View in Chronicle"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND about.labels[\"uid\"]=\"{{ events__about__labels__uid__only.value }}\" AND principal.ip=\"{{ events__principal__ip.events__principal__ip }}\" AND target.ip=\"{{ events__target__ip.events__target__ip }}\" AND security_result.summary=\"{{ events__security_result.summary }}\"{% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+    }
+    html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
   }
 
   # ----- Sets of fields for drilling ------
@@ -106344,6 +106714,56 @@ GROUP BY
   }
 }
 
+#Secure Channel Insights
+view: is_ip_internal_external {
+  derived_table: {
+    sql:SELECT
+          events__about__labels__uid__only.value  AS conn_uids,
+          events__about__labels__local__resp.value AS dest_internal,
+          events__about__labels__local__orig.value AS src_internal
+      FROM `datalake.events` AS events
+      LEFT JOIN UNNEST(events.about) as events__about
+      LEFT JOIN UNNEST(labels) as events__about__labels__uid__only ON events__about__labels__uid__only.key = 'uid'
+      LEFT JOIN UNNEST(labels) as events__about__labels__local__orig ON events__about__labels__local__orig.key = 'local_orig'
+      LEFT JOIN UNNEST(labels) as events__about__labels__local__resp ON events__about__labels__local__resp.key = 'local_resp'
+      WHERE (events.metadata.product_event_type ) = 'conn' AND (events.metadata.vendor_name = "Corelight" ) AND (events.observer.hostname ) IS NOT NULL
+      GROUP BY
+          1,
+          2,
+          3
+      ORDER BY
+          1
+      ;;
+  }
+  dimension: conn_uids {
+    sql: ${TABLE}.conn_uids;;
+  }
+  dimension: is_src_internal {
+    type: string
+    sql: ${TABLE}.src_internal;;
+  }
+  dimension: is_dest_internal {
+    type: string
+    sql: ${TABLE}.dest_internal;;
+  }
+  dimension: src_host_type {
+    type: string
+    sql: CASE
+            WHEN ${is_src_internal} = 'true' THEN 'Internal'
+            WHEN ${is_src_internal} = 'false' THEN 'External'
+            ELSE 'Unknown'
+         END;;
+  }
+  dimension: dest_host_type {
+    type: string
+    sql: CASE
+            WHEN ${is_dest_internal} = 'true' THEN 'Internal'
+            WHEN ${is_dest_internal} = 'false' THEN 'External'
+            ELSE 'Unknown'
+         END;;
+  }
+}
+
 
 #Security Posture - Self Signed Certs
 view: events__security_result__detection_fields_validation_status {
@@ -106394,5 +106814,66 @@ view: events__about__labels_viz_stats {
   dimension: value {
     type: string
     sql: ${TABLE}.value ;;
+  }
+}
+
+#Secure Channel Insights
+view: events__target__labels_cert_chain_fps {
+  dimension: key {
+    type: string
+    sql: ${TABLE}.key ;;
+  }
+  dimension: value {
+    type: string
+    sql: ${TABLE}.value ;;
+  }
+}
+
+# Secure Channel Insights
+view: x509_events_only {
+  derived_table: {
+    sql:  SELECT
+              events__about__labels_fingerprint.value  AS events__about__labels_fingerprint_value,
+              SAFE_CAST(events__about__labels_certificate_key_length.value AS  INT64)  AS events__about__labels_certificate_key_length,
+              events.network.tls.server.certificate.not_after.seconds AS not_valid_after,
+              events.network.tls.server.certificate.subject AS network__tls__server__certificate__subject
+          FROM `datalake.events` AS events
+          LEFT JOIN UNNEST(events.about) as events__about
+          LEFT JOIN UNNEST(labels) as events__about__labels_certificate_key_length ON events__about__labels_certificate_key_length.key = 'certificate_key_length'
+          LEFT JOIN UNNEST(labels) as events__about__labels_fingerprint ON events__about__labels_fingerprint.key = 'fingerprint'
+          WHERE (events.metadata.product_event_type ) = 'x509' AND (events.metadata.vendor_name = "Corelight" ) AND (events.observer.hostname) IS NOT NULL
+          GROUP BY
+              1,
+              2,
+              3,
+              4;;
+  }
+
+  dimension: fingerprint {
+    type: string
+    sql: ${TABLE}.events__about__labels_fingerprint_value ;;
+  }
+  dimension: certificate_key_length {
+    type: number
+    sql: ${TABLE}.events__about__labels_certificate_key_length ;;
+  }
+  dimension: cert_not_valid_after {
+    sql: FORMAT_TIMESTAMP("%Y-%m-%dT%H:%M:%SZ",TIMESTAMP_SECONDS(${TABLE}.not_valid_after),"UTC") ;;
+  }
+  dimension: cert_day_to_expire {
+    type: number
+    sql: ROUND((UNIX_SECONDS(TIMESTAMP(${cert_not_valid_after})) - UNIX_SECONDS(TIMESTAMP(FORMAT_TIMESTAMP("%Y-%m-%dT%H:%M:%SZ",CURRENT_TIMESTAMP(),"UTC")))) / 86400, 0) ;;
+  }
+  dimension: subject {
+    type: string
+    sql: ${TABLE}.network__tls__server__certificate__subject ;;
+  }
+  measure: max_cert_not_valid_after {
+    type: string
+    sql:  MAX(${cert_not_valid_after});;
+  }
+  measure: max_cert_day_to_expire {
+    type: max
+    sql:  ${cert_day_to_expire};;
   }
 }

--- a/views/events.view.lkml
+++ b/views/events.view.lkml
@@ -1411,6 +1411,12 @@ view: events {
     group_label: "Network Tls Client"
     group_item_label: "Server Name"
   }
+  dimension: network__tls__client__server_name_not_null {
+    type: string
+    sql: COALESCE(${TABLE}.network.tls.client.server_name, "Unknown") ;;
+    group_label: "Network Tls Client"
+    group_item_label: "Server Name Not Null"
+  }
   dimension: network__tls__client__supported_ciphers {
     hidden: yes
     sql: ${TABLE}.network.tls.client.supported_ciphers ;;
@@ -31470,11 +31476,12 @@ view: events {
   dimension: connection_type {
     type: string
     sql: CASE
-            WHEN ${tls_version_src_internal} = 'true' AND ${tls_version_dest_internal} = 'false' THEN 'Outbound'
-            WHEN ${tls_version_src_internal} = 'false' AND ${tls_version_dest_internal} = 'true' THEN 'Inbound'
-            WHEN ${tls_version_src_internal} = 'true' AND ${tls_version_dest_internal} = 'true' THEN 'Internal'
-            WHEN ${tls_version_src_internal} = 'false' AND ${tls_version_dest_internal} = 'false' THEN 'EEther'
-         END;;
+            WHEN ${is_ip_internal_external.is_src_internal} = 'true' AND ${is_ip_internal_external.is_dest_internal} = 'false' THEN 'Outbound'
+            WHEN ${is_ip_internal_external.is_src_internal} = 'false' AND ${is_ip_internal_external.is_dest_internal} = 'true' THEN 'Inbound'
+            WHEN ${is_ip_internal_external.is_src_internal} = 'true' AND ${is_ip_internal_external.is_dest_internal} = 'true' THEN 'Internal'
+            WHEN ${is_ip_internal_external.is_src_internal} = 'false' AND ${is_ip_internal_external.is_dest_internal} = 'false' THEN 'EEther'
+            ELSE 'Unknown'
+        END;;
   }
 
   #Secure Channel Insights - Network Evidence for All TLS versions seen
@@ -31569,7 +31576,7 @@ view: events {
   #Secure Channel Insights - Connections using Less Secure TLS Versions
   measure: connections_using_less_secure_tls_versions {
     type: count_distinct
-    sql:CONCAT(${events__principal__ip.events__principal__ip}, ${events__target__ip.events__target__ip}, ${events__about__labels__uid__only.value});;
+    sql:CONCAT(${network__tls__version}, ${version_status}, ${connection_type}, ${events__about__labels__uid__only.value});;
   }
 
   #Secure Channel Insights - Connections using Less Secure TLS Versions
@@ -31687,7 +31694,7 @@ view: events {
     type: count
     link: {
       label: "View in Chronicle"
-      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND network.tls.version=\"{{ network__tls__version | url_encode }}\" AND target.ip != \"\" {% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND network.tls.version=\"{{ network__tls__version | url_encode }}\" AND target.ip != \"\"{% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
     }
     html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
   }
@@ -31697,7 +31704,7 @@ view: events {
     type: count
     link: {
       label: "View in Chronicle"
-      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND about.labels[\"uid\"]=\"{{ events__about__labels__uid__only.value }}\" AND principal.ip=\"{{ events__principal__ip.events__principal__ip }}\" AND target.ip=\"{{ events__target__ip.events__target__ip }}\" AND security_result.summary=\"{{ events__security_result.summary | url_encode }}\"{% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND about.labels[\"uid\"]=\"{{ events__about__labels__uid__only.value }}\" AND principal.ip=\"{{ events__principal__ip.events__principal__ip }}\" AND target.ip=\"{{ events__target__ip.events__target__ip }}\" AND (security_result.summary=\"Automated Interaction\" OR security_result.summary=\"Keystrokes\"){% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
     }
     html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
   }
@@ -31717,7 +31724,7 @@ view: events {
     type: count
     link: {
       label: "View in Chronicle"
-      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND about.labels[\"uid\"]=\"{{ events__about__labels__uid__only.value }}\" AND principal.ip=\"{{ events__principal__ip.events__principal__ip }}\" AND target.ip=\"{{ events__target__ip.events__target__ip }}\" AND security_result.summary=\"{{ events__security_result.summary }}\"{% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND about.labels[\"uid\"]=\"{{ events__about__labels__uid__only.value }}\" AND principal.ip=\"{{ events__principal__ip.events__principal__ip }}\" AND target.ip=\"{{ events__target__ip.events__target__ip }}\" AND (security_result.summary=\"Small Client File Download\" OR security_result.summary=\"Large Client File Donwload\" OR security_result.summary=\"Small Client File Upload\" OR security_result.summary=\"Large Client File Upload\"){% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
     }
     html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
   }
@@ -31757,7 +31764,7 @@ view: events {
     type: count
     link: {
       label: "View in Chronicle"
-      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND about.labels[\"uid\"]=\"{{ events__about__labels__uid__only.value }}\" AND principal.ip=\"{{ events__principal__ip.events__principal__ip }}\" AND target.ip=\"{{ events__target__ip.events__target__ip }}\" AND security_result.summary=\"{{ events__security_result.summary }}\"{% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
+      url: "@{CHRONICLE_URL}/search?query=metadata.product_event_type=\"{{ events.metadata__product_event_type }}\" AND metadata.vendor_name=\"{{events.metadata__vendor_name}}\" AND about.labels[\"uid\"]=\"{{ events__about__labels__uid__only.value }}\" AND principal.ip=\"{{ events__principal__ip.events__principal__ip }}\" AND target.ip=\"{{ events__target__ip.events__target__ip }}\" AND (security_result.summary=\"Client Authentication Bypass\" OR security_result.summary=\"Reverse SSH Providioned\" OR security_result.summary=\"Reverse SSH Initiated\" OR security_result.summary=\"Reverse SSH Initiated Automate\" OR security_result.summary=\"Reverse SSH Logged In\" OR security_result.summary=\"Reverse SSH Keystrokes\"){% if _filters['events.observer__hostname'] %} AND observer.hostname=\"{{ _filters['events.observer__hostname'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %} {% if _filters['events.observer__namespace'] %} AND observer.namespace=\"{{ _filters['events.observer__namespace'] | replace:'\"','' | url_encode }}\"{% else %}{% endif %}&startTime={{ events.lower_date }}&endTime={{ events.upper_date }}"
     }
     html: <img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/svgs/solid/link.svg" width="15" height="15" alt="link" /> ;;
   }


### PR DESCRIPTION
**Created the Secure Channel Insights Dashboard and added all the functionality:**

Panels of the dashboard:
- Weak Certs. used Internally
- Network Evidence for Weak Key Length Certs
- Less Secure Ciphers
- Less Secure Ciphers seen in the period
- Connections using Less Secure TLS Versions (< TLS1.2)
- Network Evidence for All TLS versions seen
- Interactive Sessions and Keystrokes
- Network Evidence for Interactive Sessions and Keystrokes - SSH Inferences
- Self Signed Certs
- Network Evidence for Self Signed Internal Certificates
- Possible File Uploaded
- Possible File Transfer
- Certificates about to Expire
- Network Evidence for Self Signed Internal Certificates
- Potential Security Risks
- SSH Inferences for Potential Security Risks
- Automated SSH Session Indicators
- SSH Inferences for Potential Security Risks
- Advanced Threat Indicators
- SSH Advanced Threats Infereces

**ScreenShot:**

![image](https://github.com/user-attachments/assets/9d51e814-a945-49f1-8241-c94eae18dff0)
